### PR TITLE
Dev/icons8pngcdn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,15 @@ Features
 ========
 
 Use simple template tags to generate icons in your web application.
-Supports *Font Awesome* and *Icons8* out of the box, easily adaptable for other icon libraries.
+Supports out of the box:
+
+- `Font Awesome 4`_
+- `Bootstrap 3`_
+- `Material`_
+- `Icons8`_
+- Local files
+
+Can easily be adapted for other icon libraries.
 
 The basic usage in a Django template::
 
@@ -80,3 +88,8 @@ to think of a library that
 - And could easily be extended by users
 
 This is how we came to write and use `django-icons`.
+
+.. _Font Awesome 4: https://fontawesome.com/v4.7.0/
+.. _Bootstrap 3: https://getbootstrap.com/docs/3.3/components/#glyphicons
+.. _Material: https://material.io/tools/icons/?style=baseline
+.. _Icons8: https://icons8.com/

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Some libraries may require that you set a link to them. For that, you can use th
 .. code:: Django
 
     {% load icons %}
-    {% icon-copyright %}
+    {% icon-attribution %}
 
 
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,11 @@ This package requires a Python 3.6 or newer and Django 2.2 or newer.
 
 The combination must be supported by the Django Project. See "Supported Versions" on https://www.djangoproject.com/download/.
 
+Documentation
+=============
+
+See https://django-icons.readthedocs.io/ for complete documentation.
+
 Running the demo
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,20 @@ Features
 ========
 
 Use simple template tags to generate icons in your web application.
-Supports *Font Awesome* out of the box, easily adaptable for other icon libraries.
+Supports *Font Awesome* and *Icons8* out of the box, easily adaptable for other icon libraries.
 
 The basic usage in a Django template::
 
    {% load icons %}
    {% icon 'edit' %}
+
+
+Some libraries may require that you set a link to them. For that, you can use the following:
+
+.. code:: Django
+
+    {% load icons %}
+    {% icon-copyright %}
 
 
 Requirements

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,4 +13,5 @@ Icons for Django
    demo
    api
    templatetags
+   renderers
    settings

--- a/docs/renderers.rst
+++ b/docs/renderers.rst
@@ -1,0 +1,33 @@
+=========================
+Renderers
+=========================
+
+
+Bootstrap3
+~~~~
+
+.. autofunction:: django_icons.renderers.Bootstrap3Renderer.Bootstrap3Renderer
+
+
+Font Awesome 4
+~~~~
+
+.. autofunction:: django_icons.renderers.fontawesome.FontAwesomeRenderer
+
+
+Material
+~~~~
+
+.. autofunction:: django_icons.renderers.material.MaterialRenderer
+
+
+Icons 8
+~~~~
+
+.. autofunction:: django_icons.renderers.image.Icons8PngCdnRenderer
+
+
+Local files
+~~~~
+
+.. autofunction:: django_icons.renderers.image.ImageRenderer

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -15,3 +15,24 @@ icon
 ~~~~
 
 .. autofunction:: django_icons.templatetags.icons.icon
+
+
+Renderers
+=========
+
+Some renderers support additional parameters.
+
+
+ImageRenderer & Icons8PngCdnRenderer
+------------------------------------
+
+To get a variant representation of an icon (assuming that variant exists), you can specify:
+
+size : int
+    The size for this icon, if different from the default value. When using the ImageRenderer, the icon file name must contain that value.
+
+color : str
+    The color for this icon, if different from the default value. When using the ImageRenderer, the icon file name must contain that value.
+
+format : str
+    The format (file extension) for this icon, if different from the default value. When using the ImageRenderer, the icon file name must have that extension.

--- a/src/django_icons/__init__.py
+++ b/src/django_icons/__init__.py
@@ -45,13 +45,13 @@ def icon_attribution(renderer=None, *args, **kwargs):
     **Parameters**:
 
         renderer
-            The renderer for which to generate a copyright text
+            The renderer for which to generate an attribution text
 
             :default: The default renderer as per ``settings.py``, or ultimately `FontAwesomeRenderer`.
 
     **Usage**::
 
-        icon_copyright(renderer)
+        icon_attribution(renderer)
 
     **Example**::
 

--- a/src/django_icons/__init__.py
+++ b/src/django_icons/__init__.py
@@ -36,3 +36,30 @@ def icon(name, *args, **kwargs):
     renderer_class = get_icon_renderer(icon_kwargs.get("renderer", None))
     renderer = renderer_class(**icon_kwargs)
     return renderer.render()
+
+
+def icon_copyright(renderer=None, *args, **kwargs):
+    """
+    Render a copyright text
+
+    **Parameters**:
+
+        renderer
+            The renderer for which to generate a copyright text
+
+            :default: The default renderer as per ``settings.py``, or ultimately `FontAwesomeRenderer`.
+
+    **Usage**::
+
+        icon_copyright(renderer)
+
+    **Example**::
+
+        icon_copyright()
+        icon_copyright('Icons8PngCdnRenderer')
+        icon_copyright('Icons8PngCdnRenderer', extra_classes='my-css')
+    """
+    renderer_class = get_icon_renderer(renderer)
+    tag_kwargs = get_icon_kwargs(renderer_class.__name__, *args, **kwargs)
+    renderer = renderer_class(**tag_kwargs)
+    return renderer.render_copyright()

--- a/src/django_icons/__init__.py
+++ b/src/django_icons/__init__.py
@@ -38,9 +38,9 @@ def icon(name, *args, **kwargs):
     return renderer.render()
 
 
-def icon_copyright(renderer=None, *args, **kwargs):
+def icon_attribution(renderer=None, *args, **kwargs):
     """
-    Render a copyright text
+    Render an attribution text, to be used as a citation for the source.
 
     **Parameters**:
 
@@ -55,11 +55,11 @@ def icon_copyright(renderer=None, *args, **kwargs):
 
     **Example**::
 
-        icon_copyright()
-        icon_copyright('Icons8PngCdnRenderer')
-        icon_copyright('Icons8PngCdnRenderer', extra_classes='my-css')
+        icon_attribution()
+        icon_attribution('Icons8PngCdnRenderer')
+        icon_attribution('Icons8PngCdnRenderer', extra_classes='my-css')
     """
     renderer_class = get_icon_renderer(renderer)
     tag_kwargs = get_icon_kwargs(renderer_class.__name__, *args, **kwargs)
     renderer = renderer_class(**tag_kwargs)
-    return renderer.render_copyright()
+    return renderer.render_attribution()

--- a/src/django_icons/renderers/__init__.py
+++ b/src/django_icons/renderers/__init__.py
@@ -5,4 +5,11 @@ from .image import ImageRenderer, Icons8PngCdnRenderer
 
 from .material import MaterialRenderer
 
-__all__ = ["BaseRenderer", "Bootstrap3Renderer", "FontAwesomeRenderer", "MaterialRenderer", "ImageRenderer", "Icons8PngCdnRenderer"]
+__all__ = [
+    "BaseRenderer",
+    "Bootstrap3Renderer",
+    "FontAwesomeRenderer",
+    "MaterialRenderer",
+    "ImageRenderer",
+    "Icons8PngCdnRenderer",
+]

--- a/src/django_icons/renderers/__init__.py
+++ b/src/django_icons/renderers/__init__.py
@@ -1,7 +1,8 @@
 from .base import BaseRenderer
 from .bootstrap3 import Bootstrap3Renderer
 from .fontawesome import FontAwesomeRenderer
-from .image import ImageRenderer
+from .image import ImageRenderer, Icons8PngCdnRenderer
+
 from .material import MaterialRenderer
 
-__all__ = ["BaseRenderer", "Bootstrap3Renderer", "FontAwesomeRenderer", "MaterialRenderer", "ImageRenderer"]
+__all__ = ["BaseRenderer", "Bootstrap3Renderer", "FontAwesomeRenderer", "MaterialRenderer", "ImageRenderer", "Icons8PngCdnRenderer"]

--- a/src/django_icons/renderers/base.py
+++ b/src/django_icons/renderers/base.py
@@ -73,5 +73,5 @@ class BaseRenderer(object):
             content=mark_safe(force_str(content) if content else ""),
         )
 
-    def render_copyright(self):
+    def render_attribution(self):
         return ""

--- a/src/django_icons/renderers/base.py
+++ b/src/django_icons/renderers/base.py
@@ -74,4 +74,5 @@ class BaseRenderer(object):
         )
 
     def render_attribution(self):
+        """Render the attribution to the source of the icon library, if any."""
         return ""

--- a/src/django_icons/renderers/base.py
+++ b/src/django_icons/renderers/base.py
@@ -72,3 +72,6 @@ class BaseRenderer(object):
             attrs=mark_safe(flatatt(attrs)) if attrs else "",
             content=mark_safe(force_str(content) if content else ""),
         )
+
+    def render_copyright(self):
+        return ""

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -241,7 +241,7 @@ class Icons8PngCdnRenderer(ImageRenderer):
     @classmethod
     def get_image_root(cls):
         """
-        The root path to the images folder. By default, returns the path to a 'icons' folder inside the static folder.
+        The root path to the images folder. By default, returns the path to an 'icons' folder inside the static folder.
 
         Returns
         -------

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -183,11 +183,11 @@ class ImageRenderer(BaseRenderer):
         """
         variant = self.render_variant()  # Alters the name
         filename = (
-                self.get_image_prefix()
-                + self.name
-                + variant
-                + "."
-                + (self.kwargs.get("format", None) or self.get_image_format())
+            self.get_image_prefix()
+            + self.name
+            + variant
+            + "."
+            + (self.kwargs.get("format", None) or self.get_image_format())
         )
         return "{}/{}".format(static(self.get_image_root()), filename)
 
@@ -260,9 +260,11 @@ class Icons8PngCdnRenderer(ImageRenderer):
             Contains the patterns to match the available variant attributes.
 
         """
-        return [cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),
-                cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
-                cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None)]
+        return [
+            cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),
+            cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
+            cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
+        ]
 
     def get_path(self):
         """
@@ -287,13 +289,25 @@ class Icons8PngCdnRenderer(ImageRenderer):
     def render_copyright(self):
         from django_icons import icon
         from django_icons.css import merge_css_list
-        icotag = icon('icons8-logo', alt=_("Icons8 icon logo"), style="vertical-align:middle; width:1.5rem",
-                      extra_classes="icon-copyright",
-                      renderer=Icons8PngCdnRenderer)
-        attrs = {'class': merge_css_text(merge_css_list(self.get_extra_classes(), 'icons8-copyright'))}
+
+        icotag = icon(
+            "icons8-logo",
+            alt=_("Icons8 icon logo"),
+            style="vertical-align:middle; width:1.5rem",
+            extra_classes="icon-copyright",
+            renderer=Icons8PngCdnRenderer,
+        )
+        attrs = {
+            "class": merge_css_text(
+                merge_css_list(self.get_extra_classes(), "icons8-copyright")
+            )
+        }
         attrs = self.clean_attrs(attrs)
         return format_html(
             '<div{attrs}>{label}&nbsp;<a href="https://icons8.com/">'
             '<span>{icon}<span style="margin-left:0.25rem">Icons8</span></span>'
-            '</a></div>',
-            attrs=mark_safe(flatatt(attrs)) if attrs else "", label=_('Icons by'), icon=icotag)
+            "</a></div>",
+            attrs=mark_safe(flatatt(attrs)) if attrs else "",
+            label=_("Icons by"),
+            icon=icotag,
+        )

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -7,8 +7,8 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from django_icons.css import merge_css_text
-from django_icons.renderers.base import BaseRenderer
+from ..css import merge_css_text
+from ..renderers.base import BaseRenderer
 
 
 class ImageRenderer(BaseRenderer):
@@ -287,8 +287,8 @@ class Icons8PngCdnRenderer(ImageRenderer):
         return variant
 
     def render_copyright(self):
-        from django_icons import icon
-        from django_icons.css import merge_css_list
+        from .. import icon
+        from ..css import merge_css_list
 
         icotag = icon(
             "icons8-logo",

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -270,9 +270,9 @@ class Icons8PngCdnRenderer(ImageRenderer):
 
         """
         return [
-            cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),  # is the 'style' from icons8
-            cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
-            cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
+            cls.VariantAttributePattern("theme", r"-t:(?P<{}>\w+)", "color"),  # is the 'style' from icons8
+            cls.VariantAttributePattern("size", r"-s:(?P<{}>\w+)", None),
+            cls.VariantAttributePattern("color", r"-c:(?P<{}>\w+)", None),
         ]
 
     @classmethod

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -234,7 +234,8 @@ class ImageRenderer(BaseRenderer):
 class Icons8PngCdnRenderer(ImageRenderer):
     """
 
-    When using this Renderer, please cite the source according to https://icons8.com/license
+    When using this Renderer, please cite the source according to https://icons8.com/license; for example by using
+    `icon-attribution` templatetag.
 
     """
 
@@ -286,15 +287,15 @@ class Icons8PngCdnRenderer(ImageRenderer):
                     variant += "{}/".format(variant_attributes[v.key])
         return variant
 
-    def render_copyright(self):
+    def render_attribution(self):
         from .. import icon
         from ..css import merge_css_list
 
-        icotag = icon(
+        icontag = icon(
             "icons8-logo",
             alt=_("Icons8 icon logo"),
             style="vertical-align:middle; width:1.5rem",
-            extra_classes="icon-copyright",
+            extra_classes="icon-attribution",
             renderer=Icons8PngCdnRenderer,
         )
         attrs = {
@@ -309,5 +310,5 @@ class Icons8PngCdnRenderer(ImageRenderer):
             "</a></div>",
             attrs=mark_safe(flatatt(attrs)) if attrs else "",
             label=_("Icons by"),
-            icon=icotag,
+            icon=icontag,
         )

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -183,11 +183,11 @@ class ImageRenderer(BaseRenderer):
         """
         variant = self.render_variant()  # Alters the name
         filename = (
-            self.get_image_prefix()
-            + self.name
-            + variant
-            + "."
-            + (self.kwargs.get("format", None) or self.get_image_format())
+                self.get_image_prefix()
+                + self.name
+                + variant
+                + "."
+                + (self.kwargs.get("format", None) or self.get_image_format())
         )
         return "{}/{}".format(static(self.get_image_root()), filename)
 
@@ -212,6 +212,10 @@ class ImageRenderer(BaseRenderer):
 
     def get_attrs(self):
         attrs = super(ImageRenderer, self).get_attrs()
+        try:
+            attrs["style"] = self.kwargs["style"]
+        except KeyError:
+            pass
         # 'alt' is a mandatory img tag attribute
         cleaned_name = self.name.replace("-", " ").replace("_", " ").title()
         attrs["alt"] = self.kwargs.get("alt", _("Icon of {}").format(cleaned_name))
@@ -256,7 +260,7 @@ class Icons8PngCdnRenderer(ImageRenderer):
             Contains the patterns to match the available variant attributes.
 
         """
-        return [cls.VariantAttributePattern("style", "-y:(?P<{}>\w+)", "color"),
+        return [cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),
                 cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
                 cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None)]
 
@@ -279,3 +283,17 @@ class Icons8PngCdnRenderer(ImageRenderer):
                 if v.key in variant_attributes:
                     variant += "{}/".format(variant_attributes[v.key])
         return variant
+
+    def render_copyright(self):
+        from django_icons import icon
+        from django_icons.css import merge_css_list
+        icotag = icon('icons8-logo', alt=_("Icons8 icon logo"), style="vertical-align:middle; width:1.5rem",
+                      extra_classes="icon-copyright",
+                      renderer=Icons8PngCdnRenderer)
+        attrs = {'class': merge_css_text(merge_css_list(self.get_extra_classes(), 'icons8-copyright'))}
+        attrs = self.clean_attrs(attrs)
+        return format_html(
+            '<div{attrs}>{label}&nbsp;<a href="https://icons8.com/">'
+            '<span>{icon}<span style="margin-left:0.25rem">Icons8</span></span>'
+            '</a></div>',
+            attrs=mark_safe(flatatt(attrs)) if attrs else "", label=_('Icons by'), icon=icotag)

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -249,7 +249,7 @@ class Icons8PngCdnRenderer(ImageRenderer):
         str or callable
 
         """
-        return "https://png.icons8.com/"
+        return "https://img.icons8.com/"
 
     @classmethod
     def get_image_variant_attributes_pattern(cls):
@@ -262,7 +262,9 @@ class Icons8PngCdnRenderer(ImageRenderer):
 
         """
         return [
-            cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),
+            cls.VariantAttributePattern(
+                "theme", "-t:(?P<{}>\w+)", "color"
+            ),  # is the 'style' from icons8
             cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
             cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
         ]

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -143,9 +143,11 @@ class ImageRenderer(BaseRenderer):
                 )
         return cls._variant_attributes_regex
 
-    def get_variant_attributes(self):
+    def extract_variant_attributes(self):
         """
         Return the variant attributes.
+
+        Alters the name of the icon by removing the variant attribute definitions.
 
         :return: dict The variant attributes.
         """
@@ -160,13 +162,13 @@ class ImageRenderer(BaseRenderer):
                     self.variant_attributes[key] = default
         return self.variant_attributes
 
-    def render_variant(self):
+    def extract_variant(self):
         """
         Alter the name of the icon by removing the variant attribute definitions.
 
-        :return: str The variant to be appended to the icon name to build the path to the file in the file system.
+        :return: str The variant to be inserted in the path for the file system.
         """
-        variant_attributes = self.get_variant_attributes()
+        variant_attributes = self.extract_variant_attributes()
         variant = ""
         if variant_attributes:
             for v in self.get_image_variant_attributes_pattern():
@@ -181,7 +183,7 @@ class ImageRenderer(BaseRenderer):
         By default, the icon filename is built as '{name}[-{color}][-{size}][-{variantX}]' where '-{color}' '-{size}'
         and '-{variantX}'s are only added if there are defined (if several are defined, they are added in that order).
         """
-        variant = self.render_variant()  # Alters the name
+        variant = self.extract_variant()  # Alters the name
         filename = (
             self.get_image_prefix()
             + self.name
@@ -203,9 +205,9 @@ class ImageRenderer(BaseRenderer):
         if self.get_image_prefix():
             css_classes += " icon-{prefix}".format(prefix=self.name)
         for v_p in self.get_image_variant_attributes_pattern():
-            if v_p.key in self.get_variant_attributes():
+            if v_p.key in self.extract_variant_attributes():
                 css_classes += " icon-{variant}-{value}".format(
-                    variant=v_p.key, value=self.get_variant_attributes()[v_p.key]
+                    variant=v_p.key, value=self.extract_variant_attributes()[v_p.key]
                 )
         css_classes += " icon-{name}".format(name=self.name)
         return css_classes
@@ -244,9 +246,7 @@ class Icons8PngCdnRenderer(ImageRenderer):
         """
         The root path to the images folder. By default, returns the path to an 'icons' folder inside the static folder.
 
-        Returns
-        -------
-        str or callable
+        :return: str or callable
 
         """
         return "https://img.icons8.com/"
@@ -255,16 +255,11 @@ class Icons8PngCdnRenderer(ImageRenderer):
     def get_image_variant_attributes_pattern(cls):
         """
 
-        Returns
-        -------
-        list
-            Contains the patterns to match the available variant attributes.
+        :return: list Contains the patterns to match the available variant attributes.
 
         """
         return [
-            cls.VariantAttributePattern(
-                "theme", "-t:(?P<{}>\w+)", "color"
-            ),  # is the 'style' from icons8
+            cls.VariantAttributePattern("theme", "-t:(?P<{}>\w+)", "color"),  # is the 'style' from icons8
             cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
             cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
         ]
@@ -276,12 +271,12 @@ class Icons8PngCdnRenderer(ImageRenderer):
         By default, the icon filename is built as '{name}.{format}' where '-{color}' '-{size}'
         and '-{variantX}'s are only added if there are defined (if several are defined, they are added in that order).
         """
-        variant = self.render_variant()
+        variant = self.extract_variant()
         filename = self.name + "." + self.get_image_format()
         return self.get_image_root() + variant + filename
 
-    def render_variant(self):
-        variant_attributes = self.get_variant_attributes()
+    def extract_variant(self):
+        variant_attributes = self.extract_variant_attributes()
         variant = ""
         if variant_attributes:
             for v in self.get_image_variant_attributes_pattern():
@@ -299,12 +294,9 @@ class Icons8PngCdnRenderer(ImageRenderer):
             style="vertical-align:middle; width:1.5rem",
             extra_classes="icon-attribution",
             renderer=Icons8PngCdnRenderer,
+            # TODO support kwargs to customize at least size of the icon
         )
-        attrs = {
-            "class": merge_css_text(
-                merge_css_list(self.get_extra_classes(), "icons8-copyright")
-            )
-        }
+        attrs = {"class": merge_css_text(merge_css_list(self.get_extra_classes(), "icons8-copyright"))}
         attrs = self.clean_attrs(attrs)
         return format_html(
             '<div{attrs}>{label}&nbsp;<a href="https://icons8.com/">'

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -225,3 +225,57 @@ class ImageRenderer(BaseRenderer):
         attrs["class"] = merge_css_text(self.get_css_classes())
         attrs = self.clean_attrs(attrs)
         return format_html(builder, path=src, attrs=mark_safe(flatatt(attrs)) if attrs else "")
+
+
+class Icons8PngCdnRenderer(ImageRenderer):
+    """
+
+    When using this Renderer, please cite the source according to https://icons8.com/license
+
+    """
+
+    @classmethod
+    def get_image_root(cls):
+        """
+        The root path to the images folder. By default, returns the path to a 'icons' folder inside the static folder.
+
+        Returns
+        -------
+        str or callable
+
+        """
+        return "https://png.icons8.com/"
+
+    @classmethod
+    def get_image_variant_attributes_pattern(cls):
+        """
+
+        Returns
+        -------
+        list
+            Contains the patterns to match the available variant attributes.
+
+        """
+        return [cls.VariantAttributePattern("style", "-y:(?P<{}>\w+)", "color"),
+                cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
+                cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None)]
+
+    def get_path(self):
+        """
+        Relative path to the icon.
+
+        By default, the icon filename is built as '{name}.{format}' where '-{color}' '-{size}'
+        and '-{variantX}'s are only added if there are defined (if several are defined, they are added in that order).
+        """
+        variant = self.render_variant()
+        filename = self.name + "." + self.get_image_format()
+        return self.get_image_root() + variant + filename
+
+    def render_variant(self):
+        variant_attributes = self.get_variant_attributes()
+        variant = ""
+        if variant_attributes:
+            for v in self.get_image_variant_attributes_pattern():
+                if v.key in variant_attributes:
+                    variant += "{}/".format(variant_attributes[v.key])
+        return variant

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -302,7 +302,7 @@ class Icons8PngCdnRenderer(ImageRenderer):
             renderer=Icons8PngCdnRenderer,
             # TODO support kwargs to customize at least size of the icon
         )
-        attrs = {"class": merge_css_text(merge_css_list(self.get_extra_classes(), "icons8-copyright"))}
+        attrs = {"class": merge_css_text(merge_css_list(self.get_extra_classes(), "icons8-attribution"))}
         attrs = self.clean_attrs(attrs)
         return format_html(
             '<div{attrs}>{label}&nbsp;<a href="https://icons8.com/">'

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -109,7 +109,8 @@ class ImageRenderer(BaseRenderer):
     @classmethod
     def get_image_variant_attributes_pattern(cls):
         """
-        Return list of patterns to match the available variant attributes.
+        Return list of patterns to match the available variant attributes. The order must match how they appear in
+        the concrete path to the file.
 
         :return: list Contains the patterns to match the available variant attributes.
         """
@@ -119,11 +120,21 @@ class ImageRenderer(BaseRenderer):
         ]
 
     @classmethod
+    def get_image_variant_pattern(cls):
+        """
+        :return: str The pattern to concatenate the variant attributes. Contains at least '{}'.
+        """
+        return "-{}"
+
+    @classmethod
     def get_image_format(cls):
         """
         Return icon format, without dot.
 
         For example: 'png'.
+
+        :return: str The icon file format, without dot.
+
         """
         return "png"
 
@@ -173,7 +184,7 @@ class ImageRenderer(BaseRenderer):
         if variant_attributes:
             for v in self.get_image_variant_attributes_pattern():
                 if v.key in variant_attributes:
-                    variant += "-{}".format(variant_attributes[v.key])
+                    variant += self.get_image_variant_pattern().format(variant_attributes[v.key])
         return variant
 
     def get_path(self):
@@ -264,6 +275,10 @@ class Icons8PngCdnRenderer(ImageRenderer):
             cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
         ]
 
+    @classmethod
+    def get_image_variant_pattern(cls):
+        return "{}/"
+
     def get_path(self):
         """
         Relative path to the icon.
@@ -274,15 +289,6 @@ class Icons8PngCdnRenderer(ImageRenderer):
         variant = self.extract_variant()
         filename = self.name + "." + self.get_image_format()
         return self.get_image_root() + variant + filename
-
-    def extract_variant(self):
-        variant_attributes = self.extract_variant_attributes()
-        variant = ""
-        if variant_attributes:
-            for v in self.get_image_variant_attributes_pattern():
-                if v.key in variant_attributes:
-                    variant += "{}/".format(variant_attributes[v.key])
-        return variant
 
     def render_attribution(self):
         from .. import icon

--- a/src/django_icons/templatetags/icons.py
+++ b/src/django_icons/templatetags/icons.py
@@ -1,6 +1,6 @@
 from django import template
 
-from .. import icon
+from .. import icon, icon_copyright
 
 register = template.Library()
 
@@ -42,3 +42,31 @@ def do_icon(name, *args, **kwargs):
         {% icon 'trash' title='Delete' %}
     """
     return icon(name, *args, **kwargs)
+
+
+@register.simple_tag(name="icon-copyright")
+def do_icon_copyright(renderer=None, **kwargs):
+    """
+    Render a copyright text
+
+    This template is an interface to the `icon_copyright` function from `django_icons`
+
+
+    **Parameters**:
+
+        renderer
+            The renderer for which to generate a copyright text
+
+            :default: The default renderer as per ``settings.py``, or ultimately `FontAwesomeRenderer`.
+
+    **Usage**::
+
+        {% icon-copyright renderer %}
+
+    **Example**::
+
+        {% icon-copyright %}
+        {% icon-copyright 'Icons8PngCdnRenderer' %}
+        {% icon-copyright 'Icons8PngCdnRenderer' extra_classes='my-css' %}
+    """
+    return icon_copyright(renderer, **kwargs)

--- a/src/django_icons/templatetags/icons.py
+++ b/src/django_icons/templatetags/icons.py
@@ -1,6 +1,6 @@
 from django import template
 
-from .. import icon, icon_copyright
+from .. import icon, icon_attribution
 
 register = template.Library()
 
@@ -44,29 +44,29 @@ def do_icon(name, *args, **kwargs):
     return icon(name, *args, **kwargs)
 
 
-@register.simple_tag(name="icon-copyright")
-def do_icon_copyright(renderer=None, **kwargs):
+@register.simple_tag(name="icon-attribution")
+def do_icon_attribution(renderer=None, **kwargs):
     """
-    Render a copyright text
+    Render an attribution text, to be used as a citation for the source.
 
-    This template is an interface to the `icon_copyright` function from `django_icons`
+    This template is an interface to the `icon_attribution` function from `django_icons`.
 
 
     **Parameters**:
 
         renderer
-            The renderer for which to generate a copyright text
+            The renderer for which to generate an attribution text
 
             :default: The default renderer as per ``settings.py``, or ultimately `FontAwesomeRenderer`.
 
     **Usage**::
 
-        {% icon-copyright renderer %}
+        {% icon-attribution renderer %}
 
     **Example**::
 
-        {% icon-copyright %}
-        {% icon-copyright 'Icons8PngCdnRenderer' %}
-        {% icon-copyright 'Icons8PngCdnRenderer' extra_classes='my-css' %}
+        {% icon-attribution %}
+        {% icon-attribution 'Icons8PngCdnRenderer' %}
+        {% icon-attribution 'Icons8PngCdnRenderer' extra_classes='my-css' %}
     """
-    return icon_copyright(renderer, **kwargs)
+    return icon_attribution(renderer, **kwargs)

--- a/src/django_icons/utils.py
+++ b/src/django_icons/utils.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 from django_icons.css import merge_css_list
-from django_icons.renderers import Bootstrap3Renderer, FontAwesomeRenderer, ImageRenderer
+from django_icons.renderers import Bootstrap3Renderer, FontAwesomeRenderer, ImageRenderer, Icons8PngCdnRenderer
 from django_icons.renderers.material import MaterialRenderer
 
 DEFAULT_RENDERERS = {
@@ -12,6 +12,7 @@ DEFAULT_RENDERERS = {
     "bootstrap3": Bootstrap3Renderer,
     "material": MaterialRenderer,
     "image": ImageRenderer,
+    "icons8pngcdn": Icons8PngCdnRenderer,
 }
 
 

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -50,6 +50,7 @@ DJANGO_ICONS = {
         "bootstrap3": "Bootstrap3Renderer",
         "material": "MaterialRenderer",
         "image": "ImageRenderer",
+        "icons8pngcdn": "Icons8PngCdnRenderer",
     },
     "ICONS": {
         "delete": "trash",

--- a/tests/test_icons8pngcdn.py
+++ b/tests/test_icons8pngcdn.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from .test_template_tags import render_template
+
+
+class ImageTest(TestCase):
+    """
+    Test the Image Renderer
+    """
+
+    def test_icons(self):
+        self.assertEqual(
+            '<img src="https://png.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-icons8">',
+            render_template('{% icon "icons8" renderer="Icons8PngCdnRenderer" %}'),
+        )
+        self.assertEqual(
+            '<img src="https://png.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-style-dusk icon-size-96 icon-color-c0392b icon-icons8">',
+            render_template('{% icon "icons8-y:dusk-c:c0392b-s:96" renderer="Icons8PngCdnRenderer" %}'),
+        )
+        self.assertEqual(
+            '<img src="https://png.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-style-dusk icon-icons8">',
+            render_template('{% icon "icons8-y:dusk" renderer="Icons8PngCdnRenderer" %}'),
+        )
+        self.assertEqual(
+            '<img src="https://png.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-color-c0392b icon-icons8">',
+            render_template('{% icon "icons8-c:c0392b" renderer="Icons8PngCdnRenderer" %}'),
+        )
+        self.assertEqual(
+            '<img src="https://png.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-size-96 icon-icons8">',
+            render_template('{% icon "icons8-s:96" renderer="Icons8PngCdnRenderer" %}'),
+        )

--- a/tests/test_icons8pngcdn.py
+++ b/tests/test_icons8pngcdn.py
@@ -13,33 +13,33 @@ class ImageTest(TestCase):
 
     def test_icons(self):
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-icons8">',
+            '<img src="https://img.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-icons8">',
             render_template('{% icon "icons8" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-size-96 icon-color-c0392b icon-icons8">',
+            '<img src="https://img.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-size-96 icon-color-c0392b icon-icons8">',
             render_template(
                 '{% icon "icons8-t:dusk-c:c0392b-s:96" renderer="icons8pngcdn" %}'
             ),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-icons8">',
+            '<img src="https://img.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-icons8">',
             render_template('{% icon "icons8-t:dusk" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-color-c0392b icon-icons8">',
+            '<img src="https://img.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-color-c0392b icon-icons8">',
             render_template('{% icon "icons8-c:c0392b" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-size-96 icon-icons8">',
+            '<img src="https://img.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-size-96 icon-icons8">',
             render_template('{% icon "icons8-s:96" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<div class="icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            '<div class="icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://img.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
             render_template('{% icon-attribution "icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<div class="my-css icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            '<div class="my-css icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://img.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
             render_template(
                 '{% icon-attribution "icons8pngcdn" extra_classes="my-css" %}'
             ),

--- a/tests/test_icons8pngcdn.py
+++ b/tests/test_icons8pngcdn.py
@@ -13,22 +13,43 @@ class ImageTest(TestCase):
 
     def test_icons(self):
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-icons8">',
-            render_template('{% icon "icons8" renderer="Icons8PngCdnRenderer" %}'),
+            '<img src="https://png.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-icons8">',
+            render_template(
+                '{% icon "icons8" renderer="icons8pngcdn" %}'
+            ),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-style-dusk icon-size-96 icon-color-c0392b icon-icons8">',
-            render_template('{% icon "icons8-y:dusk-c:c0392b-s:96" renderer="Icons8PngCdnRenderer" %}'),
+            '<img src="https://png.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-size-96 icon-color-c0392b icon-icons8">',
+            render_template(
+                '{% icon "icons8-t:dusk-c:c0392b-s:96" renderer="icons8pngcdn" %}'
+            ),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-style-dusk icon-icons8">',
-            render_template('{% icon "icons8-y:dusk" renderer="Icons8PngCdnRenderer" %}'),
+            '<img src="https://png.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-icons8">',
+            render_template(
+                '{% icon "icons8-t:dusk" renderer="icons8pngcdn" %}'
+            ),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-color-c0392b icon-icons8">',
-            render_template('{% icon "icons8-c:c0392b" renderer="Icons8PngCdnRenderer" %}'),
+            '<img src="https://png.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-color-c0392b icon-icons8">',
+            render_template(
+                '{% icon "icons8-c:c0392b" renderer="icons8pngcdn" %}'
+            ),
         )
         self.assertEqual(
-            '<img src="https://png.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-style-color icon-size-96 icon-icons8">',
-            render_template('{% icon "icons8-s:96" renderer="Icons8PngCdnRenderer" %}'),
+            '<img src="https://png.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-size-96 icon-icons8">',
+            render_template(
+                '{% icon "icons8-s:96" renderer="icons8pngcdn" %}'
+            ),
+        )
+        self.assertEqual(
+            '<div class="icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            render_template(
+                '{% icon-copyright "icons8pngcdn" %}'),
+        )
+        self.assertEqual(
+            '<div class="my-css icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            render_template(
+                '{% icon-copyright "icons8pngcdn" extra_classes="my-css" %}'
+            ),
         )

--- a/tests/test_icons8pngcdn.py
+++ b/tests/test_icons8pngcdn.py
@@ -35,12 +35,12 @@ class ImageTest(TestCase):
             render_template('{% icon "icons8-s:96" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<div class="icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
-            render_template('{% icon-copyright "icons8pngcdn" %}'),
+            '<div class="icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            render_template('{% icon-attribution "icons8pngcdn" %}'),
         )
         self.assertEqual(
-            '<div class="my-css icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
+            '<div class="my-css icons8-attribution">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-attribution" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
             render_template(
-                '{% icon-copyright "icons8pngcdn" extra_classes="my-css" %}'
+                '{% icon-attribution "icons8pngcdn" extra_classes="my-css" %}'
             ),
         )

--- a/tests/test_icons8pngcdn.py
+++ b/tests/test_icons8pngcdn.py
@@ -14,9 +14,7 @@ class ImageTest(TestCase):
     def test_icons(self):
         self.assertEqual(
             '<img src="https://png.icons8.com/color/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-icons8">',
-            render_template(
-                '{% icon "icons8" renderer="icons8pngcdn" %}'
-            ),
+            render_template('{% icon "icons8" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
             '<img src="https://png.icons8.com/dusk/96/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-size-96 icon-color-c0392b icon-icons8">',
@@ -26,26 +24,19 @@ class ImageTest(TestCase):
         )
         self.assertEqual(
             '<img src="https://png.icons8.com/dusk/icons8.png" alt="Icon of Icons8" class="icon icon-theme-dusk icon-icons8">',
-            render_template(
-                '{% icon "icons8-t:dusk" renderer="icons8pngcdn" %}'
-            ),
+            render_template('{% icon "icons8-t:dusk" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
             '<img src="https://png.icons8.com/color/c0392b/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-color-c0392b icon-icons8">',
-            render_template(
-                '{% icon "icons8-c:c0392b" renderer="icons8pngcdn" %}'
-            ),
+            render_template('{% icon "icons8-c:c0392b" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
             '<img src="https://png.icons8.com/color/96/icons8.png" alt="Icon of Icons8" class="icon icon-theme-color icon-size-96 icon-icons8">',
-            render_template(
-                '{% icon "icons8-s:96" renderer="icons8pngcdn" %}'
-            ),
+            render_template('{% icon "icons8-s:96" renderer="icons8pngcdn" %}'),
         )
         self.assertEqual(
             '<div class="icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',
-            render_template(
-                '{% icon-copyright "icons8pngcdn" %}'),
+            render_template('{% icon-copyright "icons8pngcdn" %}'),
         )
         self.assertEqual(
             '<div class="my-css icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>',

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -60,11 +60,7 @@ class ImageTest(TestCase):
             '<img src="/static/icons/icons8-48.png" alt="Icon of Icons8 48" class="icon icon-icons8-48">',
             render_template('{% icon "icons8-48" renderer="ImageRenderer" %}'),
         )
-        self.assertEqual(
-            '',
-            render_template(
-                '{% icon-copyright "image" %}'),
-        )
+        self.assertEqual("", render_template('{% icon-copyright "image" %}'))
 
     @override_settings(DEBUG=False, STATIC_URL="http://static.example.com/")
     def test_path_deploy(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -60,6 +60,11 @@ class ImageTest(TestCase):
             '<img src="/static/icons/icons8-48.png" alt="Icon of Icons8 48" class="icon icon-icons8-48">',
             render_template('{% icon "icons8-48" renderer="ImageRenderer" %}'),
         )
+        self.assertEqual(
+            '',
+            render_template(
+                '{% icon-copyright "image" %}'),
+        )
 
     @override_settings(DEBUG=False, STATIC_URL="http://static.example.com/")
     def test_path_deploy(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -60,7 +60,7 @@ class ImageTest(TestCase):
             '<img src="/static/icons/icons8-48.png" alt="Icon of Icons8 48" class="icon icon-icons8-48">',
             render_template('{% icon "icons8-48" renderer="ImageRenderer" %}'),
         )
-        self.assertEqual("", render_template('{% icon-copyright "image" %}'))
+        self.assertEqual("", render_template('{% icon-attribution "image" %}'))
 
     @override_settings(DEBUG=False, STATIC_URL="http://static.example.com/")
     def test_path_deploy(self):


### PR DESCRIPTION
This is actually the reason I developed the ImageRenderer. This PR integrates icons from [Icons8](https://icons8.com/), which are using the `<img>` tag and can be fetched via their CDN. It also serves as example of how the ImageRenderer can be extended, in this case with a remote third-party icon provider.

As the usage of icons from Icons8 is free as long as you put a [link](https://icons8.com/license), I also added a new rendering function to provide a copyright notice. In this case, it will provide a little text that looks like 

<div class="my-css icons8-copyright">Icons by&nbsp;<a href="https://icons8.com/"><span><img src="https://png.icons8.com/color/icons8-logo.png" alt="Icons8 icon logo" class="icon icon-theme-color icon-icons8-logo icon-copyright" style="vertical-align:middle; width:1.5rem"><span style="margin-left:0.25rem">Icons8</span></span></a></div>

https://jsfiddle.net/c2kjm8bh/.
