### PR TITLE
Added test for a custom ImageRenderer, drop py27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: false
 language: python
 
 python:
-    - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 
 install:
     - pip install tox-travis coveralls

--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,9 @@ Features
 ========
 
 Use simple template tags to generate icons in your web application.
-Supports Font Awesome out of the box, easily adaptable for other icon libraries.
+Supports *Font Awesome* out of the box, easily adaptable for other icon libraries.
 
-The basic usage is
-
-.. code:: Django
+The basic usage in a Django template::
 
    {% load icons %}
    {% icon 'edit' %}
@@ -33,7 +31,7 @@ The basic usage is
 Requirements
 ============
 
-Django >= 1.11 and a matching Python version. Using Python 3 is strongly recommended.
+Python 3 and matching supported Django versions.
 
 
 Running the demo
@@ -41,9 +39,7 @@ Running the demo
 
 You can run the small demo app that is part of the test suite.
 This requires Django, so you may have to `pip install django` in your environment.
-To run the demo, from the root of the project (where you can find `manage.py`, run:
-
-.. code:: bash
+To run the demo, from the root of the project (where you can find `manage.py`, run::
 
    python manage.py runserver
 
@@ -51,15 +47,11 @@ To run the demo, from the root of the project (where you can find `manage.py`, r
 Running the tests
 =================
 
-The test suite uses `tox`. Run the complete test suite like this:
-
-.. code:: bash
+The test suite uses `tox`. Run the complete test suite like this::
 
    tox
 
-Run the tests only for the current environment like this:
-
-.. code:: bash
+Run the tests only for the current environment like this::
 
    python manage.py test
 

--- a/django_icons/__init__.py
+++ b/django_icons/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from .utils import get_icon_kwargs, get_icon_renderer
 
 __version__ = "0.2.1"

--- a/django_icons/renderers/image.py
+++ b/django_icons/renderers/image.py
@@ -13,10 +13,10 @@ from django_icons.renderers.base import BaseRenderer
 
 class ImageRenderer(BaseRenderer):
     """
-    Render an icon from a local file, each icon being a single file. The icon will be rendered using an <img> tag.
+    Render an icon from a local file, each icon being a single file rendered with an <img> tag.
 
     All the icons must have the same extensions. Variants of an icon can be saved under variants (color, size) of the
-    filename, following a pre-defined pattern (customizable).
+    filename, following a pre-defined pattern.
 
     For each rendered icon, the default CSS classes will be 'icon' and a composed name class 'icon-{name}' where
     {name} is the name of the icon.
@@ -35,21 +35,36 @@ class ImageRenderer(BaseRenderer):
     will produce the following tag:
         <img src="/static/icons/myicon.png'" class="icon icon-myicon" %}">
 
-    To customize the default behaviours, create you own ImageRenderer by subclassing this one and override the methods
-    to suit you needs.
+    To customize the default behaviour, create a custom ``ImageRenderer``::
 
-    The template tag supports settings keyword parameters the define the variant attributes and/or set the format. The
+        # app/renderers.py
+        from django_icons.renderers import ImageRenderer
+
+        class CustomImageRenderer(ImageRenderer):
+            def get_image_root(cls):
+                return "special-icons"
+
+        DJANGO_ICONS = {
+            "DEFAULTS": {"renderer": "fontawesome", "attrs": {"aria-hidden": True}},
+            "RENDERERS": {
+                "image": "app.renderers.CustomImageRenderer",
+            },
+            "ICONS": {
+                "edit": {"renderer": "image"},
+            }
+        }
+
+    The template tag supports settings keyword parameters to define the variant attributes and/or set the format. The
     keyword must be the key of the variant attribute. Please note that using keyword parameters will supersede the
     parsing of the name. That is, the variant attributes are set from the keyword parameters and the file name is not
     parsed.
     The format can be defined by the 'format' keyword parameter without altering the definition of variant attributes.
-
     """
 
     """
-    The pattern must contain a named grouped, where the name must be specified as `{}` as it will be injected from the
-    key. That is, the pattern used here to match a color specification looks like `-c:(?P<{}>\w+)`, where `-c:` is
-    arbitrary, `<{}>` represents the matching group name and `\w+` matches for at least one alphanumeric character
+    The VariantAttributePattern must contain a named grouped, where the name must be specified as `{}` as it will be injected from the
+    key. That is, the pattern used here to match a color specification looks like `-c:(?P<{}>\\w+)`, where `-c:` is
+    arbitrary, `<{}>` represents the matching group name and `\\w+` matches for at least one alphanumeric character
     (color code be a name or a code).
     """
     VariantAttributePattern = namedtuple(
@@ -60,7 +75,7 @@ class ImageRenderer(BaseRenderer):
     )  # Used to store the compiled regexes of the individual variant attributes
 
     def __init__(self, *args, **kwargs):
-        super(ImageRenderer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Dict used to store the variant attributes extracted from icon name
         self.variant_attributes = dict()
         # If variant attributes are set by keyword arguments, they are set here
@@ -105,8 +120,8 @@ class ImageRenderer(BaseRenderer):
 
         """
         return [
-            cls.VariantAttributePattern("color", "-c:(?P<{}>\w+)", None),
-            cls.VariantAttributePattern("size", "-s:(?P<{}>\w+)", None),
+            cls.VariantAttributePattern("color", r"-c:(?P<{}>\w+)", None),
+            cls.VariantAttributePattern("size", r"-s:(?P<{}>\w+)", None),
         ]
 
     @classmethod
@@ -218,11 +233,8 @@ class ImageRenderer(BaseRenderer):
     def get_attrs(self):
         attrs = super(ImageRenderer, self).get_attrs()
         # 'alt' is a mandatory img tag attribute
-        attrs["alt"] = self.kwargs.get(
-            "alt",
-            _("Icon of ")
-            + "{}".format(self.name.replace("-", " ").replace("_", " ").title()),
-        )
+        cleaned_name = self.name.replace("-", " ").replace("_", " ").title()
+        attrs["alt"] = self.kwargs.get("alt", _("Icon of {}").format(cleaned_name))
         return attrs
 
     def render(self):

--- a/django_icons/utils.py
+++ b/django_icons/utils.py
@@ -1,11 +1,12 @@
+import sys
+
 from django.conf import settings
-from django.utils import six
 from django.utils.module_loading import import_string
 
 from django_icons.css import merge_css_list
-from django_icons.renderers import FontAwesomeRenderer, Bootstrap3Renderer
+from django_icons.renderers import (Bootstrap3Renderer, FontAwesomeRenderer,
+                                    ImageRenderer)
 from django_icons.renderers.material import MaterialRenderer
-from django_icons.renderers import ImageRenderer
 
 DEFAULT_RENDERERS = {
     "fontawesome": FontAwesomeRenderer,
@@ -39,7 +40,7 @@ def get_icon_kwargs_from_settings(name):
     kwargs_from_settings = _get_setting("ICONS", name, {})
 
     # Settings might return single string, convert to dict with key `name`
-    if isinstance(kwargs_from_settings, six.string_types):
+    if isinstance(kwargs_from_settings, str):
         kwargs_from_settings = {"name": kwargs_from_settings}
 
     # If no name is set, set the name
@@ -109,13 +110,13 @@ def get_icon_renderer(renderer=None):
     )
 
     # Translate a name to a full path
-    if isinstance(renderer_class, six.string_types):
+    if isinstance(renderer_class, str):
 
         # Note that a dotted path remains a dotted path if it is not a name
         renderer_class = _get_icon_renderer_by_name(renderer_class)
 
         # If we still have a string, it has to be a dotted path to the class
-        if isinstance(renderer_class, six.string_types):
+        if isinstance(renderer_class, str):
             # Be kind to our own Renderers
             if "." not in renderer_class:
                 renderer_class = "django_icons.renderers.{}".format(renderer_class)

--- a/tests/app/renderers.py
+++ b/tests/app/renderers.py
@@ -1,4 +1,4 @@
-from django_icons.renderers import BaseRenderer
+from django_icons.renderers import BaseRenderer, ImageRenderer
 
 
 class CustomSvgRenderer(BaseRenderer):
@@ -19,3 +19,8 @@ class CustomSvgRenderer(BaseRenderer):
 
     def get_content(self):
         return '<use xlink:href="#icon-{name}"></use>'.format(name=self.name)
+
+
+class CustomImageRenderer(ImageRenderer):
+    def get_image_root(cls):
+        return "hd-icons"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -62,7 +62,6 @@ class ImageTest(TestCase):
             ),
         )
 
-    @override_settings()
     def test_path_dev(self):
         self.assertEqual(
             '<img src="'
@@ -87,3 +86,25 @@ class ImageTest(TestCase):
             '<img src="http://static.example.com/icons/icons8-48.png" alt="Icon of Icons8 48" class="icon icon-icons8-48">',
             render_template('{% icon "icons8-48" renderer="ImageRenderer" %}'),
         )
+
+    def test_custom_renderer(self):
+        DJANGO_ICONS = {
+            "DEFAULTS": {"renderer": "fontawesome", "attrs": {"aria-hidden": True}},
+            "RENDERERS": {
+                "image": "ImageRenderer",
+                "hd-image": "tests.app.renderers.CustomImageRenderer",
+            },
+            "ICONS": {
+                "edit": {"renderer": "image"},
+                "feather": {"renderer": "hd-image"},
+            },
+        }
+        with override_settings(DJANGO_ICONS=DJANGO_ICONS):
+            self.assertEqual(
+                render_template("{% icon 'edit' %}"),
+                '<img src="/static/icons/edit.png" alt="Icon of Edit" class="icon icon-edit">',
+            )
+            self.assertEqual(
+                render_template("{% icon 'feather' %}"),
+                '<img src="/static/hd-icons/feather.png" alt="Icon of Feather" class="icon icon-feather">',
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 minversion = 1.8.0
 envlist =
     coverage-clean
-    py27-{111}
-    py34-{111,20}
-    py35-{111,20}
-    py36-{20,master}
+    py34-{1.11,2.0}
+    py35-{1.11,2.0,2.1,2.2}
+    py36-{2.0,2.1,2.2}
     coverage-report
     flake8
     docs
@@ -15,9 +14,12 @@ commands =
     coverage run --append --source=django_icons manage.py test -v1 --noinput
 deps =
     coverage
-    111: Django>=1.11,<2.0
-    20: Django>=2.0,<2.1
+    1.11: Django==1.11.*
+    2.0: Django==2.0.*
+    2.1: Django==2.1.*
+    2.2: Django==2.2.*
     master: https://github.com/django/django/archive/master.tar.gz
+
 
 [testenv:coverage-clean]
 commands = coverage erase


### PR DESCRIPTION
- Added a test for custom ImageRenderer.
- Dropped py27 support to remove `six`-dependency to support django-master.