### PR TITLE
Prevent writing to global settings

### DIFF
--- a/src/django_icons/renderers/base.py
+++ b/src/django_icons/renderers/base.py
@@ -1,5 +1,5 @@
 from django.forms.utils import flatatt
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 
@@ -70,5 +70,5 @@ class BaseRenderer(object):
             builder,
             tag=tag,
             attrs=mark_safe(flatatt(attrs)) if attrs else "",
-            content=mark_safe(force_text(content) if content else ""),
+            content=mark_safe(force_str(content) if content else ""),
         )

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -5,7 +5,7 @@ from django.forms.utils import flatatt
 from django.templatetags.static import static
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_icons.css import merge_css_text
 from django_icons.renderers.base import BaseRenderer

--- a/src/django_icons/utils.py
+++ b/src/django_icons/utils.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.conf import settings
 from django.utils.module_loading import import_string
 
@@ -18,7 +20,7 @@ def _get_setting(section, name, default=None):
 
     try:
         # Read from settings
-        setting = settings.DJANGO_ICONS[section][name]
+        setting = deepcopy(settings.DJANGO_ICONS[section][name])
     except (AttributeError, KeyError, TypeError):
         # Set to default
         setting = default


### PR DESCRIPTION
Use deepcopy to prevent writing to editable settings dict.