### PR TITLE
Fix SafeString loss, XSS in test renderer, and misleading docs

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -11,7 +11,7 @@ if SRC_FOLDER not in sys.path:
 DEBUG = True
 ADMINS = ()
 
-SECRET_KEY = "Thanks for using django-bootstrap5!"
+SECRET_KEY = "Thanks for using django-icons!"
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 TIME_ZONE = "Europe/Amsterdam"
@@ -99,7 +99,7 @@ LOGGING = {
 DJANGO_ICONS = {
     "DEFAULTS": {"attrs": {"aria-hidden": True}},
     "ICONS": {
-        "delete": {"name": "trash", "title": "Edit", "renderer": "fontawesome4"},
+        "delete": {"name": "trash", "title": "Delete", "renderer": "fontawesome4"},
         "feather": {"renderer": "app.renderers.CustomSvgRenderer"},
         "paperplane": {"renderer": "app.renderers.CustomSvgRenderer"},
         "no-pictures-please": {

--- a/src/django_icons/core.py
+++ b/src/django_icons/core.py
@@ -85,10 +85,10 @@ def _render_settings_content(content):
     """Render content from icon settings."""
     if not isinstance(content, list):
         content = [content]
-    result = mark_safe("")
+    parts = []
     for item in content:
-        result += render_icon(**item) if isinstance(item, dict) else str(item)
-    return result
+        parts.append(render_icon(**item) if isinstance(item, dict) else str(item))
+    return mark_safe("".join(parts))
 
 
 def get_icon_kwargs_from_settings(name):

--- a/src/django_icons/renderers/image.py
+++ b/src/django_icons/renderers/image.py
@@ -37,6 +37,7 @@ class ImageRenderer(IconRenderer):
         from django_icons.renderers import ImageRenderer
 
         class CustomImageRenderer(ImageRenderer):
+            @classmethod
             def get_image_root(cls):
                 return "special-icons"
 
@@ -161,7 +162,9 @@ class ImageRenderer(IconRenderer):
 
     def render_variant(self):
         """
-        Alter the name of the icon by removing the variant attribute definitions.
+        Return the variant suffix to append to the icon filename.
+
+        Calls get_variant_attributes(), which as a side effect strips variant specifiers from self.name.
 
         :return: str The variant to be appended to the icon name to build the path to the file in the file system.
         """

--- a/tests/app/renderers.py
+++ b/tests/app/renderers.py
@@ -1,3 +1,5 @@
+from django.utils.html import format_html
+
 from django_icons.renderers import IconRenderer, ImageRenderer
 
 
@@ -20,10 +22,11 @@ class CustomSvgRenderer(IconRenderer):
         return attrs
 
     def get_content(self):
-        return f'<use xlink:href="#icon-{self.name}"></use>'
+        return format_html('<use xlink:href="#icon-{name}"></use>', name=self.name)
 
 
 class CustomImageRenderer(ImageRenderer):
+    @classmethod
     def get_image_root(cls):
         return "hd-icons"
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `_render_settings_content()` in `core.py` used `mark_safe("") +=` which loses the `SafeString` type after the first concatenation, causing double-escaping. Now accumulates parts in a list and joins with a single `mark_safe()`.
- **Security**: `CustomSvgRenderer.get_content()` in `tests/app/renderers.py` returned unescaped user input via f-string. Replaced with `format_html()` to match the pattern already used in `example/app/renderers.py`.
- **Correctness**: `CustomImageRenderer.get_image_root()` in `tests/app/renderers.py` was missing `@classmethod` decorator (parent class method is a classmethod).
- **Docs**: Fixed `@classmethod` missing from docstring example in `renderers/image.py`; fixed misleading `render_variant()` docstring; fixed `SECRET_KEY` copy referencing `django-bootstrap5`; fixed `delete` icon title showing "Edit" instead of "Delete".

## Test plan

- [ ] All 22 existing tests pass (`just test`)
- [ ] Verify `_render_settings_content()` output is `SafeString` when content list has multiple items
- [ ] Verify `CustomSvgRenderer.get_content()` escapes special characters in icon names

🤖 Generated with [Claude Code](https://claude.com/claude-code)