### PR TITLE
Fix README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ pip install django-icons
 In your `settings.py`, add `django_icons` to `INSTALLED_APPS` and define an icon.
 
 ```python
-
 INSTALLED_APPS = (
     # ...
     "django_icons",


### PR DESCRIPTION
## Summary
A stray blank line at the top of an embedded Python code block in README.md was failing `ruff format --check`, which blocks `just lint` in CI — on every PR, including ones with nothing to do with README.md (e.g. #638, #639, both currently red because of this).

## Test plan
- [x] `just lint` — now passes
- [x] `just test` — 22 passed, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)