### PR TITLE
Note in AGENTS.md: re-run just upgrade after dependency constraint changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Never invoke `python`, `pip`, or `ruff` directly. All commands go through `just`
 
 `uv.lock` is fully generated — never manually resolve merge conflicts in it. On conflict: accept either side, then run `just upgrade` to regenerate.
 
+Also run `just upgrade` after changing any dependency constraint in `pyproject.toml` (e.g. bumping the Django floor) — otherwise `uv.lock`'s own `requires-dist` metadata goes stale and silently drifts from `pyproject.toml`.
+
 ## Key commands
 
 ```


### PR DESCRIPTION
## Summary
- We've hit stale \`uv.lock\` metadata (\`requires-dist\` not matching \`pyproject.toml\`) multiple times across the Zostera Django packages after bumping a Django floor without regenerating the lockfile. Documents the fix in AGENTS.md next to the existing merge-conflict note.