### PR TITLE
Add typos spell checking to just lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
+- Add `typos` spell checking to `just lint`.
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
 - Add support for Django 6.1.
 - Drop support for Django 4.2 (EOL).

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ install:
 @lint:
     uvx ruff format --check
     uvx ruff check
+    uvx typos
 
 # Run test with coverage
 @test-cov *ARGS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,7 @@ source-include = [
 
 [tool.check-manifest]
 ignore = ["uv.lock", "pyproject.toml.orig"]
+
+[tool.typos.default]
+# Subresource Integrity hashes are base64; they mint words that look like typos.
+extend-ignore-re = ['sha\d+-[A-Za-z0-9+/=]{40,}']


### PR DESCRIPTION
## Summary

Adds `uvx typos` as a third step in `just lint`, following the existing zero-install `uvx` pattern used by ruff. CI picks it up for free — `ci.yml` already runs `just lint`, and the matrix, docs, and build jobs gate on `needs: [lint]`.

Propagated from **django-marina** ([zostera/django-marina#669](https://github.com/zostera/django-marina/pull/669)), the canonical source for shared tooling per `PACKAGING.md`. Both the `justfile` line and `[tool.typos.default]` are copied verbatim — the config takes no per-package substitution.

**Why `typos` and not `codespell`, and not both.** Both do the same job, so running both means two allowlists to maintain and false positives triaged twice for no extra signal. `typos` respects `.gitignore`; codespell does not, and in this repo family it reports dozens of findings from vendored docs build assets under gitignored build directories, needing a hand-maintained `--skip` list that rots as build layout changes.

**SRI hash exclusion.** `[tool.typos.default] extend-ignore-re` skips Subresource Integrity hashes, whose base64 produces letter runs the checker reads as misspellings. A pattern is used rather than `extend-words` entries — those bless a word globally to silence one hash, and need re-editing on every CDN version bump.

## Test plan

- [x] `just lint` passes on this branch
- [x] Regex verified against all five repos before propagating, no regressions
- [x] The one finding here was an SRI hash false positive in `example/templates/base.html:102`, silenced by the pattern; no real typos in this repo