### PR TITLE
Add a 15-minute timeout to every CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -30,6 +31,7 @@ jobs:
 
   python_django_matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint]
     strategy:
       fail-fast: false
@@ -94,6 +96,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint]
     steps:
       - uses: actions/checkout@v7
@@ -114,6 +117,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -134,6 +138,7 @@ jobs:
   tests:
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [python_django_matrix, lint, docs, build]
     steps:
       - name: Check tests matrix status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a 15-minute `timeout-minutes` to every CI job.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `typos` spell checking to `just lint`.
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.


### PR DESCRIPTION
## Summary

A `python_django_matrix` job in django-bootstrap4 hung inside `sudo apt-get update` when the Azure Ubuntu mirror stopped responding, then sat idle until GitHub killed it at the 6-hour default cap:

```
2026-08-17T21:34:04Z Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
2026-08-18T03:33:35Z ##[error]The operation was canceled.
```

Six hours of runner time burned on a network stall, and the PR surfaced it as a plain job failure that looked like a test failure.

Adds `timeout-minutes: 15` to all five jobs. No job here takes more than about 30 seconds, so this is roughly 30x headroom on a normal run while turning a hang into a fast, clearly attributable failure.

Applied to every job rather than only the matrix: the step that hung is runner setup, which all jobs perform.

## Test plan

- [x] `ci.yml` parses as valid YAML; all 5 jobs (`lint`, `python_django_matrix`, `build`, `docs`, `tests`) carry `timeout-minutes: 15`
- [x] CI green on this PR

## Note

`PACKAGING.md` lists `ci.yml` under "Synced identically (copy verbatim)", but the five repos have **three** different shapes today — django-bootstrap3/4/5 carry `apt-get update` + GDAL steps that django-marina and django-icons do not, and bootstrap3 has them in a different job than bootstrap4/5. This PR changes only the timeout and leaves that divergence untouched.