### PR TITLE
Add maintenance-round section and release-note ordering to MAINTAINING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a maintenance-round section and release-note ordering convention to MAINTAINING.md.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `typos` spell checking to `just lint`.
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -23,6 +23,24 @@ copy always drifts out of sync with the files that actually enforce it.
   it's cut, so the interpreter itself is rarely the blocker. Only make the job blocking once
   test dependencies with C extensions publish wheels for it, if any are in use.
 
+## Maintenance round
+
+Start every maintenance round — and every release — by reconciling the support matrix with
+reality, not from memory:
+
+1. Check [endoflife.date/python](https://endoflife.date/python) and
+   [endoflife.date/django](https://endoflife.date/django) for what is currently supported.
+   The JSON endpoints (`https://endoflife.date/api/python.json`, `.../django.json`) are easier
+   to diff against the matrix than the pages.
+2. Drop every cycle that has gone EOL, and add every new one, per the policy above.
+3. Reconcile all three sources of truth together — `tox.ini` (`envlist`),
+   `.github/workflows/ci.yml` (`python_django_matrix`), and `pyproject.toml` (classifiers and
+   the `Django` dependency). They drift independently, so check all three even when only one
+   looks wrong.
+4. Record any change as a `CHANGELOG.md` entry — dropping a cycle raises the dependency floor
+   and is a breaking change for anyone on it. Under the `YY.N` version scheme the number
+   carries no such signal, so the note is the only warning those users get.
+
 ## Release process
 
 1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
@@ -31,3 +49,24 @@ copy always drifts out of sync with the files that actually enforce it.
 4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
 
 `just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.
+
+Order the release notes by category, in this order:
+
+1. Security fixes
+2. Dropped Python/Django cycles
+3. Added Python/Django cycles
+4. Bug fixes
+5. Features
+6. Tooling and internal changes
+7. Everything else
+
+The audience for these notes is someone upgrading, not someone shopping — so what might break
+them comes before what is new for them. That is why fixes sort above features, unlike Keep a
+Changelog, which lists Added first.
+
+Security goes above even the support matrix: a user scanning the notes must not have to read
+past a Django version line to find out they were vulnerable.
+
+If an entry is a breaking behavior change rather than a plain fix — rendered output changes,
+a default changes — prefix it with `**Breaking:**`. It sorts under bug fixes, where it would
+otherwise read as routine.


### PR DESCRIPTION
## Summary

Propagated from django-marina ([zostera/django-marina#673](https://github.com/zostera/django-marina/pull/673)), the canonical source for shared tooling per `PACKAGING.md`. Both blocks are copied verbatim — they take no per-package substitution.

**Maintenance round.** The version support policy already said to track endoflife.date, but nothing said *when* to look. This makes it the first step of a maintenance round and of every release, so the matrix gets reconciled against reality rather than from memory. It also records that `tox.ini`, `ci.yml`, and `pyproject.toml` drift independently and must be checked together.

**Release-note ordering.** Security → dropped Python/Django → added Python/Django → bug fixes → features → tooling → other.

Fixes sort above features because the audience for release notes is someone upgrading, not someone shopping — unlike Keep a Changelog, which lists Added first. Security sorts above even the support matrix: a user scanning the notes should not have to read past a Django version line to learn they were vulnerable. Also adds a `**Breaking:**` prefix convention for behavior changes that would otherwise read as routine bug fixes.

## Test plan

- [x] `just lint` passes
- [x] Both blocks verified byte-identical to django-marina's canonical version
- [x] Docs only — no behavior change