### PR TITLE
Release 26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Breaking:** Fix `SafeString` loss in `_render_settings_content` — when `DJANGO_ICONS` settings content mixed plain strings with icon dicts, `SafeString.__add__` degraded the accumulator to a plain `str` and the whole result was escaped, rendering icon markup as visible text. Parts are now joined and marked safe once. String content in settings is consequently emitted as HTML rather than escaped (#635).
+- Fix typo in the `icon()` deprecation warning ("user" -> "use") (#634).
+- Fix a misleading `render_variant()` docstring and a missing `@classmethod` in the `ImageRenderer` usage example (#635).
+- Use `format_html()` in the test app's `CustomSvgRenderer.get_content()` to prevent XSS, and add a missing `@classmethod` to `CustomImageRenderer.get_image_root` — test app only, not shipped in the wheel (#635).
+- Fix the example project's `SECRET_KEY`, copied from django-bootstrap5, and a delete icon labelled "Edit" (#635).
+- Add AGENTS.md (#634).
 - Add a maintenance-round section and release-note ordering convention to MAINTAINING.md.
 - Add a 15-minute `timeout-minutes` to every CI job.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-## Unreleased
+## 26.2 (2026-08-28)
 
+- Drop support for Django 4.2 (EOL).
+- Add support for Django 6.1.
 - **Breaking:** Fix `SafeString` loss in `_render_settings_content` — when `DJANGO_ICONS` settings content mixed plain strings with icon dicts, `SafeString.__add__` degraded the accumulator to a plain `str` and the whole result was escaped, rendering icon markup as visible text. Parts are now joined and marked safe once. String content in settings is consequently emitted as HTML rather than escaped (#635).
 - Fix typo in the `icon()` deprecation warning ("user" -> "use") (#634).
 - Fix a misleading `render_variant()` docstring and a missing `@classmethod` in the `ImageRenderer` usage example (#635).
 - Use `format_html()` in the test app's `CustomSvgRenderer.get_content()` to prevent XSS, and add a missing `@classmethod` to `CustomImageRenderer.get_image_root` — test app only, not shipped in the wheel (#635).
-- Fix the example project's `SECRET_KEY`, copied from django-bootstrap5, and a delete icon labelled "Edit" (#635).
 - Add AGENTS.md (#634).
 - Add a maintenance-round section and release-note ordering convention to MAINTAINING.md.
 - Add a 15-minute `timeout-minutes` to every CI job.
 - Fix `just build`: ignore the transient `pyproject.toml.orig` in `check-manifest`.
 - Add `typos` spell checking to `just lint`.
 - Add MAINTAINING.md (version-support policy, release process); add scope statement and PR-review checklist to CONTRIBUTING.md.
-- Add support for Django 6.1.
-- Drop support for Django 4.2 (EOL).
+- Fix the example project's `SECRET_KEY`, copied from django-bootstrap5, and a delete icon labelled "Edit" (#635).
 
 ## 26.1 (2026-01-02)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = ["LICENSE", "AUTHORS"]
 name = "django-icons"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "26.1"
+version = "26.2"
 
 [project.urls]
 Changelog = "https://github.com/zostera/django-icons/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Stamps the Unreleased section as **26.2** and bumps `version` from `26.1`.

Two commits since v26.1 changed shipped code but recorded **nothing** in the CHANGELOG, so the first commit here documents them. Without that, the most significant change in this release would have shipped invisible.

## The undocumented changes

**`7017812` — `SafeString` loss in `_render_settings_content()`.** Django's `SafeString.__add__` returns a `SafeString` only when the right operand is `SafeData`. `render_icon()` returns one; `str(item)` does not. So as soon as `DJANGO_ICONS` settings content mixed a plain string with icon dicts, the accumulator degraded to plain `str` and the **entire result was escaped** — icon markup rendered as visible text. Parts are now joined and marked safe once.

Marked `**Breaking:**` because rendered output changes: string content in settings is now emitted as HTML rather than escaped. That content is developer-controlled configuration, not user input, so it is not an injection vector — but it is a real behavior change.

**`d9eb3db`** — typo in the `icon()` deprecation warning (`"user"` → `"use"`), plus AGENTS.md.

Also documented: docstring corrections in `renderers/image.py`, the test-app `format_html()` change, and example-project fixes.

## On the "XSS" in commit 7017812

That commit's subject mentions XSS, but the fix is in `tests/app/renderers.py`. Verified against a built distribution:

```
wheel top-level: ['django_icons', 'django_icons-26.1.dist-info']   ships tests/: False
sdist ships tests/: True
```

Test code is not importable from the installed package. **This is not a security fix for users**, and the release notes deliberately do not present it as one — it sorts under tooling, described as test-app only. Overstating it would be worse than the original omission.

## Test plan

- [x] `just lint` passes
- [x] 22 tests pass
- [x] `just build` passes end to end, producing `django_icons-26.2` artifacts
- [x] Verified wheel/sdist contents to confirm the XSS fix is not in shipped code
- [x] Support matrix checked against endoflife.date: Python 3.10–3.14, Django 5.2/6.0/6.1

## After merge

Per `MAINTAINING.md`: pull `main`, `just build`, `just release-tag`. The tag push publishes to PyPI irreversibly — latest is currently 26.1 and 26.2 does not exist.